### PR TITLE
Include Makefile for 64bit SINGE library compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ amd64 processor.  I'm not sure anymore how to get Daphne compiled for
     cd src/vldp2
     ./configure --disable-accel-detect
     make -f Makefile.linux_x64
-    cd ..
+    cd ../game/singe
+    make -f Makefile.linux_x64
+    cd ../..
     ln -s Makefile.vars.linux_x64 Makefile.vars
     make
     cd ..
@@ -34,7 +36,7 @@ amd64 processor.  I'm not sure anymore how to get Daphne compiled for
 Cutting and pasting the following in a Debian GNU/Linux system (or
 derivative), will install all prerequisite development libraries.
 
-    sudo apt install libsdl-dev libglew-dev libvorbis-dev
+    sudo apt install libsdl-dev libglew-dev libvorbis-dev libsdl-image1.2-dev libsdl-ttf2.0-dev
 
 ## Laserdisc images and ROMs
 
@@ -47,16 +49,30 @@ If you do not install them, you'll get an error message like:
 
     ROM dl_f2_u1.bin couldn't be found in roms/lair/, or in ./roms/lair.zip
 
-## Running Daphne
+### SINGE based game files
 
-This version of daphne comes with a simple command line frontend:
+Game data using the singe plugin should be copied into `~/.daphne/singe/`
+within a sub-diretory name matching the game title.
+
+The primary `.singe` and `.txt` framefiles should also match this naming
+convention within the game sub-directory.
+
+    ~/.daphne/singe/maddog/maddog.singe
+    ~/.daphne/singe/maddog/maddog.txt
+
+## Running Daphne or SINGE
+
+This version of daphne comes with simple command line frontends:
 
     ./run.sh lair
+    ./singe.sh maddog
 
 In order to | press this
 ------------|-----------
 start a game| 5 5 1
 play a game | arrow keys, ctrl, alt
+
+SINGE games may utilise mouse control.
 
 For a list of all possible keys, please see [the daphne wiki](https://www.daphne-emu.com:9443/mediawiki/index.php/input). 
 

--- a/singe.sh
+++ b/singe.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 SCRIPT_DIR=`dirname "$0"`
+if realpath / >/dev/null; then SCRIPT_DIR=$(realpath "$SCRIPT_DIR"); fi
 DAPHNE_BIN=daphne.bin
 DAPHNE_SHARE=~/.daphne
 
@@ -8,30 +9,40 @@ echo "Singe Launcher : Script dir is $SCRIPT_DIR"
 cd "$SCRIPT_DIR"
 
 # point to our linked libs that user may not have
-LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$SCRIPT_DIR:$DAPHNE_SHARE:$LD_LIBRARY_PATH
 
-if [ -z $1 ] ; then
-	echo "Specify a game to try: timegal"
-	exit
+if [ "$1" = "-fullscreen" ]; then
+    FULLSCREEN="-fullscreen"
+    shift
 fi
 
+if [ -z $1 ] ; then
+	echo "Specify a game to try: "
+	echo
+	echo "\t$0 [-fullscreen] <gamename>"
+	echo
+
+        echo -n "Games available: "
+	for game in $(ls $DAPHNE_SHARE/singe/); do
+        	echo -n "$game "
+	done
+	echo
+	exit
+
+fi
 
 #strace -o strace.txt \
 ./$DAPHNE_BIN singe vldp \
+$FULLSCREEN \
 -framefile $DAPHNE_SHARE/singe/$1/$1.txt \
 -script $DAPHNE_SHARE/singe/$1/$1.singe \
 -homedir $DAPHNE_SHARE \
 -datadir $DAPHNE_SHARE \
--blank_searches \
--min_seek_delay 1000 \
--seek_frames_per_ms 20 \
 -sound_buffer 2048 \
 -noserversend \
--x 640 \
--y 480
+-x 800 \
+-y 600 
 
-#-bank 0 11111001 \
-#-bank 1 00100111 \
 
 EXIT_CODE=$?
 
@@ -46,4 +57,3 @@ if [ "$EXIT_CODE" -ne "0" ] ; then
 		echo "DaphneLoader failed with an unknown exit code : $EXIT_CODE."
 	fi
 fi
-

--- a/src/game/singe/Makefile.linux_x64
+++ b/src/game/singe/Makefile.linux_x64
@@ -1,0 +1,43 @@
+# Makefile for SINGE
+# Written by RDG2010
+
+# TODO: Add dependencies
+
+CC = gcc
+# Uncomment for debugging purposes
+#DFLAGS = -pg
+#DFLAGS = -ggdb -DSINGE_DEBUG -DDEBUG
+
+# Benchmarking version
+#DFLAGS = -O3 -march=i686 -fomit-frame-pointer -funroll-loops -DVLDP_BENCHMARK
+
+# Standard version
+DFLAGS = -O3 -fomit-frame-pointer -funroll-loops -fPIC
+
+CPPFLAGS = -fPIC
+
+CFLAGS = ${DFLAGS} `sdl-config --cflags` 
+LIBS = `sdl-config --libs` -lSDL_image -lSDL_ttf
+
+OBJS =  singeproxy.o lbaselib.o ldblib.o ldump.o lapi.o lauxlib.o lcode.o ldebug.o ldo.o \
+	lfunc.o	lgc.o linit.o liolib.o llex.o lmathlib.o lmem.o \
+	loadlib.o lobject.o lopcodes.o loslib.o lparser.o lstate.o lstrlib.o	\
+	lstring.o ltable.o ltablib.o ltm.o \
+	lundump.o lvm.o lzio.o lrandom.o random.o
+
+LIBNAME =	libsinge.so
+
+.SUFFIXES:	.c .cpp 
+
+.c.o:
+		${CC} ${CFLAGS} -c $< -o $@
+
+all:		singe
+
+singe:		${OBJS}
+		${CC} -shared -o ${LIBNAME} ${OBJS} ${LIBS}
+		cp ${LIBNAME} ../../../.
+
+clean:
+		rm -f ${LIBNAME} ${OBJS}
+		

--- a/src/game/singe/ldump.c
+++ b/src/game/singe/ldump.c
@@ -26,7 +26,7 @@ typedef struct {
 #define DumpMem(b,n,size,D)	DumpBlock(b,(n)*(size),D)
 #define DumpVar(x,D)	 	DumpMem(&x,1,sizeof(x),D)
 
-static void DumpBlock(const void* b, size_t size, DumpState* D)
+static void DumpBlock(const void* b, LUAC_STR_SIZE_TYPE size, DumpState* D)
 {
  if (D->status==0)
  {
@@ -52,7 +52,7 @@ static void DumpNumber(lua_Number x, DumpState* D)
  DumpVar(x,D);
 }
 
-static void DumpVector(const void* b, int n, size_t size, DumpState* D)
+static void DumpVector(const void* b, int n, LUAC_STR_SIZE_TYPE size, DumpState* D)
 {
  DumpInt(n,D);
  DumpMem(b,n,size,D);
@@ -62,12 +62,12 @@ static void DumpString(const TString* s, DumpState* D)
 {
  if (s==NULL || getstr(s)==NULL)
  {
-  size_t size=0;
+  LUAC_STR_SIZE_TYPE size=0;
   DumpVar(size,D);
  }
  else
  {
-  size_t size=s->tsv.len+1;		/* include trailing '\0' */
+  LUAC_STR_SIZE_TYPE size=s->tsv.len+1;		/* include trailing '\0' */
   DumpVar(size,D);
   DumpBlock(getstr(s),size,D);
  }

--- a/src/game/singe/lundump.c
+++ b/src/game/singe/lundump.c
@@ -45,9 +45,9 @@ static void error(LoadState* S, const char* why)
 #define LoadVar(S,x)		LoadMem(S,&x,1,sizeof(x))
 #define LoadVector(S,b,n,size)	LoadMem(S,b,n,size)
 
-static void LoadBlock(LoadState* S, void* b, size_t size)
+static void LoadBlock(LoadState* S, void* b, LUAC_STR_SIZE_TYPE size)
 {
- size_t r=luaZ_read(S->Z,b,size);
+ LUAC_STR_SIZE_TYPE r=luaZ_read(S->Z,b,size);
  IF (r!=0, "unexpected end");
 }
 
@@ -75,7 +75,7 @@ static lua_Number LoadNumber(LoadState* S)
 
 static TString* LoadString(LoadState* S)
 {
- size_t size;
+ LUAC_STR_SIZE_TYPE size;
  LoadVar(S,size);
  if (size==0)
   return NULL;
@@ -220,7 +220,7 @@ void luaU_header (char* h)
  *h++=(char)LUAC_FORMAT;
  *h++=(char)*(char*)&x;				/* endianness */
  *h++=(char)sizeof(int);
- *h++=(char)sizeof(size_t);
+ *h++=(char)sizeof(LUAC_STR_SIZE_TYPE);
  *h++=(char)sizeof(Instruction);
  *h++=(char)sizeof(lua_Number);
  *h++=(char)(((lua_Number)0.5)==0);		/* is lua_Number integral? */

--- a/src/game/singe/lundump.h
+++ b/src/game/singe/lundump.h
@@ -10,6 +10,12 @@
 #include "lobject.h"
 #include "lzio.h"
 
+/* default */
+/* #define LUAC_STR_SIZE_TYPE size_t */
+
+/* for 32 bit compatible bytecode */
+#define LUAC_STR_SIZE_TYPE int
+
 /* load one chunk; from lundump.c */
 LUAI_FUNC Proto* luaU_undump (lua_State* L, ZIO* Z, Mbuffer* buff, const char* name);
 


### PR DESCRIPTION
Allow singe to read **32bit LUA bytecode .singe** files in the correct endian fashion
on legacy games (Time Gal, Ninja Hayate). Configurable in header file _lundump.h_

Update singe.sh and README.md to reflect changes.