### PR TITLE
'segfault' on SDL overlay caused by a negative vertical offset value

### DIFF
--- a/src/ldp-out/ldp-vldp.cpp
+++ b/src/ldp-out/ldp-vldp.cpp
@@ -224,8 +224,9 @@ bool ldp_vldp::init_player()
 							g_vertical_offset = g_game->get_video_row_offset();
 
 							// We get negative integer on certain SDL overlay games which break &yuv_palette[*gamevid_pixels]
-							// in prepare_frame_callback_with_overlay() causing a segfault. Fix negation here....
-							if ( g_vertical_offset < 0 ) g_vertical_offset = abs(g_vertical_offset);
+							// in prepare_frame_callback_with_overlay() causing a segfault. We zero out the variable for
+							// correct alignment...
+							if ( g_vertical_offset < 0 ) g_vertical_offset = 0;
 
 							// if testing has been requested then run them ...
 							if (m_testing)

--- a/src/ldp-out/ldp-vldp.cpp
+++ b/src/ldp-out/ldp-vldp.cpp
@@ -223,6 +223,10 @@ bool ldp_vldp::init_player()
 							// this number is used repeatedly, so we calculate it once
 							g_vertical_offset = g_game->get_video_row_offset();
 
+							// We get negative integer on certain SDL overlay games which break &yuv_palette[*gamevid_pixels]
+							// in prepare_frame_callback_with_overlay() causing a segfault. Fix negation here....
+							if ( g_vertical_offset < 0 ) g_vertical_offset = abs(g_vertical_offset);
+
 							// if testing has been requested then run them ...
 							if (m_testing)
 							{


### PR DESCRIPTION
when utilised in palette = &yuv_palette[*gamevid_pixels]

We now negate the negation on calculation .... so that
*gamevid_pixels is correctly set in prepare_frame_callback_with_overlay()

Fixes: **astron, bega, cobraab, esh, galaxy, gpworld, interstellar & roadblaster**

Reading symbols from /home/user/Games/Daphne/daphne.bin...done.
[New LWP 6945]
[New LWP 6939]
[New LWP 6944]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `./daphne.bin astron vldp -framefile /home/user/.daphne/vldp/astron/astron.txt -h'.
Program terminated with signal SIGSEGV, Segmentation fault.
    at ldp-vldp.cpp:1780
1780                                                    palette = &yuv_palette[*gamevid_pixels];
[Current thread is 1 (Thread 0x7f2bf0d74700 (LWP 6945))]
(gdb) bt
    at ldp-vldp.cpp:1780
    at vldp/vldp_internal.c:171
    at pthread_create.c:456
    at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
(gdb) quit