### PR TITLE
Extra boundary checking on g_vertical_offset and new flag -keymapfile

### DIFF
--- a/daphne-changelog.txt
+++ b/daphne-changelog.txt
@@ -1,6 +1,10 @@
 Daphne Changelog
 -------------------------
 
+v1.0.13.1
+- Add -keymapfile flag to specify alternate dapinput.ini keymap files.
+- Restrict -vertical_stretch values to 0-25 to avoid segfault in g_vertical_offset calculations
+
 v1.0.13
 - Changed inpout library so it only loads (and thus installs itself) if parallel port is actually used.
 

--- a/src/daphne.cpp
+++ b/src/daphne.cpp
@@ -89,7 +89,7 @@ using namespace std;
 
 const char *get_daphne_version()
 {
-	return "1.0.13";
+	return "1.0.13.1";
 }
 
 unsigned char get_filename(char *s, unsigned char n)

--- a/src/daphne.rc
+++ b/src/daphne.rc
@@ -53,8 +53,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,1,0,13
- PRODUCTVERSION 0,1,0,13
+ FILEVERSION 0,1,0,13.1
+ PRODUCTVERSION 0,1,0,13.1
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x3L
@@ -70,12 +70,12 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription", "DAPHNE, a Laserdisc Arcade Game Emulator"
-            VALUE "FileVersion", "0, 1, 0, 13"
+            VALUE "FileVersion", "0, 1, 0, 13, 1"
             VALUE "InternalName", "daphne"
             VALUE "LegalCopyright", "Copyright (C) 1999-2013 Matt Ownby"
             VALUE "OriginalFilename", "daphne.exe"
             VALUE "ProductName", " daphne Application"
-            VALUE "ProductVersion", "0, 1, 0, 13"
+            VALUE "ProductVersion", "0, 1, 0, 13, 1"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/io/cmdline.cpp
+++ b/src/io/cmdline.cpp
@@ -705,6 +705,13 @@ bool parse_cmd_line(int argc, char **argv)
 				result = false;
 			}
 		}
+
+		// specify an alternate dapinput.ini file (located in home or app directory)
+		else if (strcasecmp(s, "-keymapfile")==0)
+		{
+			get_next_word(s, sizeof(s));
+			set_inputini_file(s);
+		}
 		
 		// if they are defining an alternate soundtrack to be used by VLDP
 		else if (strcasecmp(s, "-altaudio")==0)
@@ -886,6 +893,14 @@ bool parse_cmd_line(int argc, char **argv)
 
 			get_next_word(s, sizeof(s));
 			i = atoi(s);
+			if (i > 25) {
+				i=25;
+				printline("WARNING: vertical stretch restricted to 25 max.");
+			}
+			if (i < 0) {
+				i=0;
+				printline("WARNING: vertical stretch cannot be negative. zeroed.");
+			}
 			if (the_ldp != NULL)
 			{
 				the_ldp->set_vertical_stretch(i);

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -57,6 +57,9 @@ bool g_consoledown = false;			// whether the console is down or not
 bool g_alt_pressed = false;	// whether the ALT key is presssed (for ALT-Enter combo)
 unsigned int idle_timer; // added by JFA for -idleexit
 
+string g_inputini_file = "dapinput.ini"; // Default keymap file
+bool m_altInputFileSet = false;
+
 const double STICKY_COIN_SECONDS = 0.125;	// how many seconds a coin acceptor is forced to be "depressed" and how many seconds it is forced to be "released"
 Uint32 g_sticky_coin_cycles = 0;	// STICKY_COIN_SECONDS * get_cpu_hz(0), cannot be calculated statically
 queue<struct coin_input> g_coin_queue;	// keeps track of coin input to guarantee that coins don't get missed if the cpu is busy (during seeks for example)
@@ -166,10 +169,18 @@ void CFG_Keys()
 	string key_name = "", sval1 = "", sval2 = "", sval3 = "", eq_sign = "";
 	int val1 = 0, val2 = 0, val3 = 0;
 //	bool done = false;
-	// find where the dapinput ini file is (if the file doesn't exist, this string will be empty)
-	string strDapInput = g_homedir.find_file("dapinput.ini", true);
-int max_buttons = (int) (sizeof(joystick_buttons_map) / sizeof(int));
+	int max_buttons = (int) (sizeof(joystick_buttons_map) / sizeof(int));
+
+	if (m_altInputFileSet) {
+		string keyinput_notice = "Loading alternate keymap file: ";
+		keyinput_notice += g_inputini_file.c_str();
+		printline(keyinput_notice.c_str());
+	}
+
+	// find where the keymap ini file is (if the file doesn't exist, this string will be empty)
+	string strDapInput = g_homedir.find_file(g_inputini_file.c_str(), true);
 	io = mpo_open(strDapInput.c_str(), MPO_OPEN_READONLY);
+
 	if (io)
 	{
 		printline("Remapping input ...");
@@ -894,4 +905,11 @@ void reset_idle(void)
 void set_use_joystick(bool val)
 {
 	g_use_joystick = val;
+}
+
+// Allow us to specify an alternate keymap.ini file
+void set_inputini_file(const char *inputFile)
+{
+	m_altInputFileSet = true;
+	g_inputini_file = inputFile;
 }

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -172,8 +172,7 @@ void CFG_Keys()
 	int max_buttons = (int) (sizeof(joystick_buttons_map) / sizeof(int));
 
 #ifdef LINUX
-	string fullpath = strdup(g_inputini_file.c_str());
-	string inifile = basename(fullpath.c_str());
+	string inifile = basename(g_inputini_file.c_str());
 #else
 	string inifile = strdup(g_inputini_file.c_str());
 #endif

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -171,16 +171,22 @@ void CFG_Keys()
 //	bool done = false;
 	int max_buttons = (int) (sizeof(joystick_buttons_map) / sizeof(int));
 
+#ifdef LINUX
+	string fullpath = strdup(g_inputini_file.c_str());
+	string inifile = basename(fullpath.c_str());
+#else
+	string inifile = strdup(g_inputini_file.c_str());
+#endif
+
 	if (m_altInputFileSet) {
 		string keyinput_notice = "Loading alternate keymap file: ";
-		keyinput_notice += g_inputini_file.c_str();
+		keyinput_notice += inifile.c_str();
 		printline(keyinput_notice.c_str());
 	}
 
 	// find where the keymap ini file is (if the file doesn't exist, this string will be empty)
-	string strDapInput = g_homedir.find_file(g_inputini_file.c_str(), true);
+	string strDapInput = g_homedir.find_file(inifile.c_str(), true);
 	io = mpo_open(strDapInput.c_str(), MPO_OPEN_READONLY);
-
 	if (io)
 	{
 		printline("Remapping input ...");

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -91,6 +91,7 @@ void input_disable(Uint8);
 inline void add_coin_to_queue(bool enabled, Uint8 val);
 void reset_idle(void); // added by JFA
 void set_use_joystick(bool val);
+void set_inputini_file(const char *inputFile);
 
 #endif // INPUT_H
 


### PR DESCRIPTION
Added extra boundary checking on g_vertical_offset negative values causing segfault. 
And restrict input range of -vertical_stretch from 0 to 25 to this cause.

Pushing back as contains extra checks on earlier pull request, 

**HOWEVER,** also adds a new flag (feature) for alternate keymap files. 
Allows specifying UP/DOWN swap keymap files for flight based games, as an example

Not certain you want to accept feature additions, or indeed if this should include a 
_1.0.13.1_ version change.

Can be addition fields in _run.sh_

```
    astron|blazer|cobra|galaxy|interstellar|mach3|uvt)
        VLDP_DIR="vldp"
        DAPINPUT="-keymapfile flight.ini"
        ;;
```

```
./$DAPHNE_BIN $1 vldp \
$FASTBOOT \
$FULLSCREEN \
$DAPINPUT \
. . .
```
