### PR TITLE
Fix error-prone cast syntax

### DIFF
--- a/src/cpu/nes6502.cpp
+++ b/src/cpu/nes6502.cpp
@@ -297,10 +297,10 @@
    if (condition) \
    { \
       IMMEDIATE_BYTE(btemp); \
-      if (((int8) btemp + (PC & 0x00FF)) & 0x100) \
+      if (((int8_t) btemp + (PC & 0x00FF)) & 0x100) \
          ADD_CYCLES(1); \
       ADD_CYCLES(3); \
-      PC += ((int8) btemp); \
+      PC += ((int8_t) btemp); \
    } \
    else \
    { \


### PR DESCRIPTION
This crashed Road Blaster on the Pi.

https://github.com/pjft/daphne-emu/commit/6fd8f61ee2739f3952f6d58781c0064953c2cf66

