### PR TITLE
Force char to be signed - Fixes more Pi issues

### DIFF
--- a/src/Makefile.vars.linux_x64
+++ b/src/Makefile.vars.linux_x64
@@ -11,7 +11,7 @@ export CC=gcc
 # optimized version 
 # NOTE : gcc 3.x has a bug that causes compilation to choke on m80.cpp 
 # If you want to -DGCC_X86_ASM for extra speed, you have to use g++ 3.0 or earlier 
-DFLAGS = -O3 -fexpensive-optimizations -funroll-loops -fPIC 
+DFLAGS = -O3 -fexpensive-optimizations -funroll-loops -fPIC -fsigned-char
 
 # this is to be exported for MMX assembly optimization 
 #export USE_MMX = 1 


### PR DESCRIPTION
Desktop PC:

Debian GNU/Linux 9.1 (stretch)
gcc version 6.3.0 20170516 (Debian 6.3.0-18)
Intel(R) Core(TM) i3-4150
libgcc-6-dev: 6.3.0-18
char is signed

Raspberry Pi3:

Raspbian GNU/Linux 9.1 (stretch)
gcc version 6.3.0 20170516 (Raspbian 6.3.0-18+rpi1)
ARMv7 Processor rev 4 (v7l)
libgcc-6-dev: 6.3.0-18+rpi
char is unsigned