### PR TITLE
Add Makefile for RPi to force signed char.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ amd64 processor.  I'm not sure anymore how to get Daphne compiled for
     cd ../game/singe
     make -f Makefile.linux_x64
     cd ../..
+
+    # For amd64
     ln -s Makefile.vars.linux_x64 Makefile.vars
+
+    # For Raspberry Pi
+    ln -s Makefile.vars.linux_x64_RPi Makefile.vars
+
     make
     cd ..
     mkdir -p ~/.daphne

--- a/src/Makefile.vars.linux_x64_RPi
+++ b/src/Makefile.vars.linux_x64_RPi
@@ -1,0 +1,29 @@
+# This file contains linux-specific environment variables 
+# It is included by Makefile if a symlink is created to point to it 
+
+export CXX=g++ 
+export CC=gcc 
+
+# debugging version 
+#DFLAGS = -g -DCPU_DEBUG 
+#DFLAGS = -ggdb -DCPU_DEBUG -DDEBUG -O0
+
+# optimized version 
+# NOTE : gcc 3.x has a bug that causes compilation to choke on m80.cpp 
+# If you want to -DGCC_X86_ASM for extra speed, you have to use g++ 3.0 or earlier 
+DFLAGS = -O3 -fexpensive-optimizations -funroll-loops -fPIC -fsigned-char
+
+# this is to be exported for MMX assembly optimization 
+#export USE_MMX = 1 
+
+# uncomment this to link VLDP statically instead of dynamically 
+#export STATIC_VLDP = 1 
+#export STATIC_SINGE = 1
+
+# platform-specific compile flags 
+# Add -DBUILD_SINGE to enable SINGE
+PFLAGS = ${DFLAGS} `sdl-config --cflags` -DUNIX -DLINUX \
+	-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DUSE_OPENGL -DBUILD_SINGE
+
+# platform-specific lib flags 
+LIBS = `sdl-config --libs` -ldl -lz -logg -lvorbis -lvorbisfile -lGLEW -lGL


### PR DESCRIPTION
This fixes game issues on the RPi (Badlands). But has the following caveats:

https://stackoverflow.com/questions/46463064/what-causes-a-char-to-be-signed-or-unsigned-when-using-gcc/46463173
https://stackoverflow.com/questions/3093669/why-unsigned-types-are-more-efficient-in-arm-cpu/6532932#6532932

Think it best to pull out the RPi requirement, rather than force globally.....